### PR TITLE
removed clearing of scrolls since it makes scrolls unsuable in most c…

### DIFF
--- a/Result/AbstractResultsIterator.php
+++ b/Result/AbstractResultsIterator.php
@@ -107,17 +107,6 @@ abstract class AbstractResultsIterator implements \Countable, \Iterator
     }
 
     /**
-     * Destructor.
-     */
-    public function __destruct()
-    {
-        // Clear scroll if initialized
-        if ($this->isScrollable()) {
-            $this->manager->clearScroll($this->scrollId);
-        }
-    }
-
-    /**
      * @return array
      */
     public function getRaw()


### PR DESCRIPTION
…ases

Scrolls have a defined lifetime in minutes so it is not neccessary removing them at the end of each request (in the destructor), so the destructor is not needed in this case.